### PR TITLE
chore(zone): drop redundant search types and GET

### DIFF
--- a/autodns_test.go
+++ b/autodns_test.go
@@ -54,24 +54,25 @@ var mockZoneResponse = autodns.ResponseZone{
 	},
 }
 
-// Mock zone records covering all supported record types
+// Mock zone records covering all supported record types.
+// AutoDNS uses an empty Name for apex records, not "@".
 var mockZoneRecords = []autodns.ZoneRecord{
-	{Name: "@", Type: "A", Value: "192.168.1.1", TTL: 3600},
+	{Name: "", Type: "A", Value: "192.168.1.1", TTL: 3600},
 	{Name: "www", Type: "A", Value: "192.168.1.2", TTL: 3600},
 	{Name: "ipv6", Type: "AAAA", Value: "2001:db8::1", TTL: 3600},
 	{Name: "mail", Type: "CNAME", Value: "mailserver.example.org", TTL: 3600},
-	{Name: "@", Type: "MX", Pref: ptr(10), Value: "mail.example.org", TTL: 3600},
-	{Name: "@", Type: "MX", Pref: ptr(20), Value: "backup.example.org", TTL: 3600},
-	{Name: "@", Type: "NS", Value: "ns1.example.org", TTL: 86400},
-	{Name: "@", Type: "NS", Value: "ns2.example.org", TTL: 86400},
+	{Name: "", Type: "MX", Pref: ptr(10), Value: "mail.example.org", TTL: 3600},
+	{Name: "", Type: "MX", Pref: ptr(20), Value: "backup.example.org", TTL: 3600},
+	{Name: "", Type: "NS", Value: "ns1.example.org", TTL: 86400},
+	{Name: "", Type: "NS", Value: "ns2.example.org", TTL: 86400},
 	{Name: "_sip._tcp", Type: "SRV", Value: "10 5 5060 sipserver.example.org", TTL: 3600},
-	{Name: "@", Type: "TXT", Value: "v=spf1 include:_spf.example.org ~all", TTL: 3600},
+	{Name: "", Type: "TXT", Value: "v=spf1 include:_spf.example.org ~all", TTL: 3600},
 	{Name: "test", Type: "TXT", Value: "test-verification-string", TTL: 300},
 	{Name: "custom", Type: "CAA", Value: "0 issue \"letsencrypt.org\"", TTL: 86400},
 }
 
 // Mock search response for zone lookup
-var mockSearchResponse = autodns.ResponseSearch{
+var mockSearchResponse = autodns.ResponseZone{
 	AutoDNSResponse: autodns.AutoDNSResponse{
 		STID: "test-search-stid-67890",
 		Status: struct {
@@ -84,7 +85,7 @@ var mockSearchResponse = autodns.ResponseSearch{
 			Text: ptr("Search successful"),
 		},
 	},
-	Data: []autodns.ResponseSearchItem{
+	Data: []autodns.ZoneItem{
 		{
 			Created:    "2023-10-18T13:56:47.000+0200",
 			Updated:    "2024-10-25T13:16:43.000+0200",

--- a/convert_test.go
+++ b/convert_test.go
@@ -20,9 +20,9 @@ func TestConversion(t *testing.T) {
 		}{
 			{
 				name:  "A record",
-				input: mockZoneRecords[0], // "@", "A", "192.168.1.1"
+				input: mockZoneRecords[0], // "", "A", "192.168.1.1"
 				expected: &libdns.Address{
-					Name: "@",
+					Name: "",
 					IP:   netip.MustParseAddr("192.168.1.1"),
 					TTL:  3600 * time.Second,
 				},
@@ -47,9 +47,9 @@ func TestConversion(t *testing.T) {
 			},
 			{
 				name:  "MX record",
-				input: mockZoneRecords[4], // "@", "MX", "10 mail.example.org"
+				input: mockZoneRecords[4], // "", "MX", pref=10, "mail.example.org"
 				expected: &libdns.MX{
-					Name:       "@",
+					Name:       "",
 					Preference: 10,
 					Target:     "mail.example.org",
 					TTL:        3600 * time.Second,
@@ -57,9 +57,9 @@ func TestConversion(t *testing.T) {
 			},
 			{
 				name:  "NS record",
-				input: mockZoneRecords[6], // "@", "NS", "ns1.example.org"
+				input: mockZoneRecords[6], // "", "NS", "ns1.example.org"
 				expected: &libdns.NS{
-					Name:   "@",
+					Name:   "",
 					Target: "ns1.example.org",
 					TTL:    86400 * time.Second,
 				},
@@ -78,9 +78,9 @@ func TestConversion(t *testing.T) {
 			},
 			{
 				name:  "TXT record",
-				input: mockZoneRecords[9], // "@", "TXT", "v=spf1 include:_spf.example.org ~all"
+				input: mockZoneRecords[9], // "", "TXT", "v=spf1 include:_spf.example.org ~all"
 				expected: &libdns.TXT{
-					Name: "@",
+					Name: "",
 					Text: "v=spf1 include:_spf.example.org ~all",
 					TTL:  3600 * time.Second,
 				},

--- a/request.go
+++ b/request.go
@@ -83,11 +83,6 @@ func check(statusResponse, statusExpected int, result any) error {
 	}
 
 	switch rt := result.(type) {
-	case ResponseSearch:
-		if rt.Status.Type != "ERROR" {
-			return nil
-		}
-		return NewError(rt.Messages)
 	case AutoDNSResponse:
 		if rt.Status.Type != "ERROR" {
 			return nil

--- a/sdk.go
+++ b/sdk.go
@@ -9,7 +9,7 @@ import (
 
 // checkZone servers as a check if the zone exists and returns the required data
 // (origin and nameserver to retrieve the actual zone).
-func (p *Provider) checkZone(ctx context.Context, zone string) (*ResponseSearchItem, error) {
+func (p *Provider) checkZone(ctx context.Context, zone string) (*ZoneItem, error) {
 	zone = strings.TrimSuffix(zone, ".")
 
 	filter := map[string]string{
@@ -32,7 +32,7 @@ func (p *Provider) checkZone(ctx context.Context, zone string) (*ResponseSearchI
 		return nil, err
 	}
 
-	var result ResponseSearch
+	var result ResponseZone
 	if err := p.parseResponse(resp, &result); err != nil {
 		return nil, fmt.Errorf("checkZone: %s", err)
 	}
@@ -50,9 +50,7 @@ func (p *Provider) checkZone(ctx context.Context, zone string) (*ResponseSearchI
 
 // getZone returns the zone.
 func (p *Provider) getZone(ctx context.Context, origin, nameserver, zone string) (*ResponseZone, error) {
-	req, err := p.buildRequest(ctx, http.MethodGet, p.buildURL("zone/"+origin+"/"+nameserver), RequestZone{
-		Domain: zone,
-	})
+	req, err := p.buildRequest(ctx, http.MethodGet, p.buildURL("zone/"+origin+"/"+nameserver), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/types.go
+++ b/types.go
@@ -17,10 +17,6 @@ type AutoDNSUser struct {
 	User    string `json:"user"`
 }
 
-type RequestZone struct {
-	Domain string `json:"domain"`
-}
-
 type AutoDNSMessage struct {
 	Text    string          `json:"text"`
 	Objects []AutoDNSObject `json:"objects"`
@@ -43,44 +39,29 @@ type AutoDNSResponse struct {
 	Messages []*AutoDNSMessage `json:"messages,omitempty"`
 }
 
-type ResponseSearch struct {
-	AutoDNSResponse
-	Data []ResponseSearchItem `json:"data"`
-}
-
+// Example payload returned for a /zone/_search hit (search results omit
+// resourceRecords and SOA; full zone fields appear via GET /zone/{name}/{ns}).
+//
+//	{
+//		"created": "2023-10-18T13:56:47.000+0200",
+//		"updated": "2024-10-25T13:16:43.000+0200",
+//		"origin": "something.example.org",
+//		"nameServerGroup": "ns14.net",
+//		"owner": {
+//		  "context": 4,
+//		  "user": "user"
+//		},
+//		"updater": {
+//		  "context": 4,
+//		  "user": "user"
+//		},
+//		"domainsafe": false,
+//		"wwwInclude": false,
+//		"virtualNameServer": "a.ns14.net"
+//	}
 type ResponseZone struct {
 	AutoDNSResponse
 	Data []ZoneItem `json:"data"`
-}
-
-// {
-// 	"created": "2023-10-18T13:56:47.000+0200",
-// 	"updated": "2024-10-25T13:16:43.000+0200",
-// 	"origin": "something.example.org",
-// 	"nameServerGroup": "ns14.net",
-// 	"owner": {
-// 	  "context": 4,
-// 	  "user": "user"
-// 	},
-// 	"updater": {
-// 	  "context": 4,
-// 	  "user": "user"
-// 	},
-// 	"domainsafe": false,
-// 	"wwwInclude": false,
-// 	"virtualNameServer": "a.ns14.net"
-// }
-
-type ResponseSearchItem struct {
-	Created    string      `json:"created"`
-	Updated    string      `json:"updated"`
-	Origin     string      `json:"origin"`
-	NSGroup    string      `json:"nameServerGroup"`
-	Owner      AutoDNSUser `json:"owner"`
-	Updater    AutoDNSUser `json:"updater"`
-	DomainSafe bool        `json:"domainsafe"`
-	WWWInclude bool        `json:"wwwInclude"`
-	Nameserver string      `json:"virtualNameServer"`
 }
 
 //	{


### PR DESCRIPTION
/zone/_search returns full Zone objects per the swagger spec, so
ResponseSearchItem was an almost duplicate subset of ZoneItem;
collapse both ResponseSearch and ResponseSearchItem into
ResponseZone/ZoneItem.

drop the GET body sent by getZone — the spec defines no request
body for zoneInfo.

switch test mocks from "@" to "" for apex records — confirmed live
against test zone: AutoDNS literally returns "" for apex names.
