### PR TITLE
fix: format object descr in AutoDNSError.Error

### DIFF
--- a/types.go
+++ b/types.go
@@ -231,7 +231,7 @@ func (m *AutoDNSError) Error() string {
 	for _, m := range m.messages {
 		objects := []string{}
 		for _, o := range m.Objects {
-			objects = append(objects, "%s (type: %s)", o.Value, o.Type)
+			objects = append(objects, fmt.Sprintf("%s (type: %s)", o.Value, o.Type))
 		}
 
 		errs = append(errs, fmt.Sprintf("%s, code: %s, objects: %s",


### PR DESCRIPTION
append was being given the format string and its two args as three
separate slice elements, so error messages surfaced "%s (type: %s)"
literally followed by raw value/type strings. Use fmt.Sprintf.
